### PR TITLE
Adicinando 'validationRules'

### DIFF
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -70,7 +70,7 @@ class Filters extends BaseFilters
     public array $globals = [
         'before' => [
             // 'honeypot',
-            // 'csrf',
+            'csrf', // Cross-Site Request Forgery | exceções caso necessário exemplo: => ['except' => ['api/record/save']]
             // 'invalidchars',
         ],
         'after' => [

--- a/app/Models/CursosModel.php
+++ b/app/Models/CursosModel.php
@@ -7,12 +7,12 @@ use CodeIgniter\Model;
 class CursosModel extends Model
 {
     protected $table            = 'cursos';
-    protected $primaryKey       = 'id';
+    protected $primaryKey       = 'curso_id';
     protected $useAutoIncrement = true;
     protected $returnType       = 'array';
     protected $useSoftDeletes   = false;
     protected $protectFields    = true;
-    protected $allowedFields    = [];
+    protected $allowedFields    = ['nome', 'matriz'];
 
     protected bool $allowEmptyInserts = false;
     protected bool $updateOnlyChanged = true;
@@ -28,7 +28,11 @@ class CursosModel extends Model
     protected $deletedField  = 'deleted_at';
 
     // Validation
-    protected $validationRules      = [];
+    protected $validationRules = [
+        'curso_id' => 'permit_empty|is_natural_no_zero|max_length[11]',
+        'nome' => 'required|is_unique[cursos.nome,curso_id,{curso_id}]|max_length[128]',
+        'matriz' => 'required|is_not_unique[matrizes.matriz_id]|max_length[11]'
+    ];
     protected $validationMessages   = [];
     protected $skipValidation       = false;
     protected $cleanValidationRules = true;

--- a/app/Models/DisciplinasModel.php
+++ b/app/Models/DisciplinasModel.php
@@ -7,12 +7,12 @@ use CodeIgniter\Model;
 class DisciplinasModel extends Model
 {
     protected $table            = 'disciplinas';
-    protected $primaryKey       = 'id';
+    protected $primaryKey       = 'disciplinas_id';
     protected $useAutoIncrement = true;
     protected $returnType       = 'array';
     protected $useSoftDeletes   = false;
     protected $protectFields    = true;
-    protected $allowedFields    = [];
+    protected $allowedFields    = ['nome', 'codigo', 'matriz', 'ch', 'periodo', 'abreviatura'];
 
     protected bool $allowEmptyInserts = false;
     protected bool $updateOnlyChanged = true;
@@ -28,7 +28,15 @@ class DisciplinasModel extends Model
     protected $deletedField  = 'deleted_at';
 
     // Validation
-    protected $validationRules      = [];
+    protected $validationRules = [
+        'disciplina_id' => 'permit_empty|is_natural_no_zero|max_length[11]',
+        'nome' => 'required|max_length[128]',
+        'codigo' => 'required|is_unique[disciplinas.codigo,disciplina_id,{disciplina_id}]',
+        'matriz' => 'required|is_not_unique[matrizes.matriz_id]|max_length[11]',
+        'ch' => 'required|integer|max_length[4]',
+        'periodo' => 'required|integer|max_length[2]',
+        'abreviatura' => 'permit_empty|max_length[32]',
+    ];
     protected $validationMessages   = [];
     protected $skipValidation       = false;
     protected $cleanValidationRules = true;

--- a/app/Models/DisciplinasModel.php
+++ b/app/Models/DisciplinasModel.php
@@ -7,7 +7,7 @@ use CodeIgniter\Model;
 class DisciplinasModel extends Model
 {
     protected $table            = 'disciplinas';
-    protected $primaryKey       = 'disciplinas_id';
+    protected $primaryKey       = 'disciplina_id';
     protected $useAutoIncrement = true;
     protected $returnType       = 'array';
     protected $useSoftDeletes   = false;

--- a/app/Models/MatrizCurricularModel.php
+++ b/app/Models/MatrizCurricularModel.php
@@ -6,13 +6,13 @@ use CodeIgniter\Model;
 
 class MatrizCurricularModel extends Model
 {
-    protected $table            = 'matrizcurriculars';
-    protected $primaryKey       = 'id';
+    protected $table            = 'matrizes';
+    protected $primaryKey       = 'matriz_id';
     protected $useAutoIncrement = true;
     protected $returnType       = 'array';
     protected $useSoftDeletes   = false;
     protected $protectFields    = true;
-    protected $allowedFields    = [];
+    protected $allowedFields    = ['matriz_id','nome'];
 
     protected bool $allowEmptyInserts = false;
     protected bool $updateOnlyChanged = true;
@@ -28,7 +28,10 @@ class MatrizCurricularModel extends Model
     protected $deletedField  = 'deleted_at';
 
     // Validation
-    protected $validationRules      = [];
+    protected $validationRules = [
+        'matriz_id' => 'is_natural_no_zero|max_length[11]',
+        'nome' => 'required|max_length[128]',
+    ];
     protected $validationMessages   = [];
     protected $skipValidation       = false;
     protected $cleanValidationRules = true;

--- a/app/Models/ProfessorModel.php
+++ b/app/Models/ProfessorModel.php
@@ -6,13 +6,13 @@ use CodeIgniter\Model;
 
 class ProfessorModel extends Model
 {
-    protected $table            = 'professors';
-    protected $primaryKey       = 'id';
+    protected $table            = 'professores';
+    protected $primaryKey       = 'professor_id';
     protected $useAutoIncrement = true;
     protected $returnType       = 'array';
     protected $useSoftDeletes   = false;
     protected $protectFields    = true;
-    protected $allowedFields    = [];
+    protected $allowedFields    = ['nome', 'siape'];
 
     protected bool $allowEmptyInserts = false;
     protected bool $updateOnlyChanged = true;
@@ -28,7 +28,11 @@ class ProfessorModel extends Model
     protected $deletedField  = 'deleted_at';
 
     // Validation
-    protected $validationRules      = [];
+    protected $validationRules = [
+        'professor_id' => 'permit_empty|is_natural_no_zero|max_length[11]',
+        'nome' => 'required|is_unique[professores.nome,professor_id,{professor_id}]|max_length[96]',
+        'siape' => 'permit_empty|is_unique[professores.siape,professor_id,{professor_id}]|exact_length[7]',
+    ];
     protected $validationMessages   = [];
     protected $skipValidation       = false;
     protected $cleanValidationRules = true;

--- a/app/Models/TemposAulasModel.php
+++ b/app/Models/TemposAulasModel.php
@@ -6,13 +6,13 @@ use CodeIgniter\Model;
 
 class TemposAulasModel extends Model
 {
-    protected $table            = 'temposaulas';
-    protected $primaryKey       = 'id';
+    protected $table            = 'tempos_de_aula';
+    protected $primaryKey       = 'tempo_id';
     protected $useAutoIncrement = true;
     protected $returnType       = 'array';
     protected $useSoftDeletes   = false;
     protected $protectFields    = true;
-    protected $allowedFields    = [];
+    protected $allowedFields    = ['tempo_id','time_inicio', 'time_fim'];
 
     protected bool $allowEmptyInserts = false;
     protected bool $updateOnlyChanged = true;
@@ -28,7 +28,11 @@ class TemposAulasModel extends Model
     protected $deletedField  = 'deleted_at';
 
     // Validation
-    protected $validationRules      = [];
+    protected $validationRules = [
+        'tempo_id' => 'is_natural_no_zero|max_length[11]',
+        'time_inicio' => 'required|regex_match[/^([01]\d|2[0-3]):[0-5]\d$/]', //valida de acordo com o hórario 24 horas 00:00 até 23:59
+        'time_fim' => 'required|regex_match[/^([01]\d|2[0-3]):[0-5]\d$/]', //mesma validação de cima :D.
+    ];
     protected $validationMessages   = [];
     protected $skipValidation       = false;
     protected $cleanValidationRules = true;

--- a/app/Models/TurmasModel.php
+++ b/app/Models/TurmasModel.php
@@ -7,12 +7,12 @@ use CodeIgniter\Model;
 class TurmasModel extends Model
 {
     protected $table            = 'turmas';
-    protected $primaryKey       = 'id';
+    protected $primaryKey       = 'turma_id';
     protected $useAutoIncrement = true;
     protected $returnType       = 'array';
     protected $useSoftDeletes   = false;
     protected $protectFields    = true;
-    protected $allowedFields    = [];
+    protected $allowedFields    = ['turma_id', 'codigo', 'sigla', 'ano', 'semestre', 'curso', 'tempos_diarios', 'tabela_de_horarios', 'tabela_de_horarios_preferenciais'];
 
     protected bool $allowEmptyInserts = false;
     protected bool $updateOnlyChanged = true;
@@ -28,7 +28,17 @@ class TurmasModel extends Model
     protected $deletedField  = 'deleted_at';
 
     // Validation
-    protected $validationRules      = [];
+    protected $validationRules = [
+        'turma_id' => 'is_natural_no_zero|max_length[11]',
+        'codigo' => 'required|max_length[32]',
+        'sigla' => 'required|max_length[32]',
+        'ano' => 'required|regex_match[/^(20)\d{2}$/]', //regex valida se o ano começa com 20 e aceita qualquer outros 2 dígitos no fim | 2000 até 2099. issue RF05.
+        'semestre' => 'required|regex_match[/^[12]$/]', //verifica se 1 ou 2.
+        'curso' => 'required|max_length[11]|is_not_unique[cursos.curso_id]',
+        'tempos_diarios' => 'permit_empty|is_natural, max_length[2]',
+        // 'tabela_de_horarios' => '',
+        // 'tabela_de_horarios_preferenciais' => '',
+    ];
     protected $validationMessages   = [];
     protected $skipValidation       = false;
     protected $cleanValidationRules = true;


### PR DESCRIPTION
### Testes Realizados

#### Model Matriz
- **Testes com valores nulos**: Erro amparado pela validação.
- **Teste com matriz_id duplicado**: Validado pelo banco de dados. A tag `unique` funciona para impedir duplicidade de IDs, mas problemas podem ocorrer em atualizações de registros. Não foi testada a atualização.

#### Model Professor
- **Testes com valores nulos**: Erro amparado pela validação.
- **Teste com Siape nulo**: Aceito pela validação, pois o Siape não é obrigatório.
- **Teste com todos os valores preenchidos**: Aceito como esperado.

**Observações**: O atributo `professor_id` não será aceito manualmente, conforme a configuração `allowedFields`.

#### Model Curso
- **Testes com valores nulos**: Erro amparado pela validação.
- **Teste com matriz não cadastrada**: Erro amparado pela validação.
- **Teste com valores corretos**: Aceito pela validação.
- **Teste com valores duplicados**: Erro amparado pela validação. O nome do curso deve ser único.

**Observações**: O atributo `curso_id` não será aceito manualmente, conforme a configuração `allowedFields`.

#### Model Turma
- **Testes com valores nulos**: Erro amparado pela validação.
- **Teste com ano = 1999, semestre = 3 e curso inexistente**: Erros amparados pela validação. O ano não está no intervalo esperado, o semestre está incorreto e o curso não está cadastrado no banco.
- **Teste com valores corretos**: Teste não finalizado. A conclusão depende de esclarecimentos sobre os horários.

#### Model TemposAulas
- **Testes com valores nulos**: Erro amparado pela validação.
- **Teste com tempo no formato errado (11,22 e 12.33)**: Erro amparado pela validação. O formato esperado é HH:MM.
- **Teste com valores corretos**: Aceito pela validação.

#### Model Disciplinas
- **Testes com valores nulos**: Erro amparado pela validação.
- **Teste com valores errados (matriz = valor_inexistente, ch = 'A', periodo = 'A')**: Erros amparados pela validação. A matriz precisa ser um valor existente, e CH e período devem ser inteiros.
- **Teste com valores corretos**: Aceito pela validação.
- **Teste com código duplicado e CH maior que 4 dígitos**: Erros amparados pela validação.

**Observações**: O atributo `disciplina_id` não será aceito manualmente, conforme a configuração `allowedFields`.

#### Observações Gerais
- **AmbientesModel**: Não foi modificado. Ainda não há migration para esta tabela.
- **Testes adicionais**: Quaisquer novos testes necessários, estarei à disposição para testar e corrigir conforme necessário.
